### PR TITLE
Missing line in mobility Makefile

### DIFF
--- a/airflow/mobility/Makefile
+++ b/airflow/mobility/Makefile
@@ -1,3 +1,4 @@
 
 include ../../lib/include.airflow.mk
 include ../../lib/include.mk
+include ../../lib/include.python.mk


### PR DESCRIPTION
Added the missing include.python.mk like in mobility/Makefile﻿
